### PR TITLE
Add MIT License and ignore simulator artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 __pycache__/
+*.vcd
+work/
+build/
+*.log

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Yakir1991
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -22,5 +22,4 @@ This repository contains a SystemVerilog verification environment for a simple f
 2. Run `testbench` to execute the random and directed test cases from the generator.
 3. At the end of the run the scoreboard prints the number of detected errors.
 
-## License
-This project is provided for educational purposes and carries no specific license.
+This project is licensed under the MIT License. See the LICENSE file for details.


### PR DESCRIPTION
## Summary
- add MIT License text
- exclude simulator outputs in `.gitignore`
- document the license in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cf9cacba8832989bc9a1a005b320b