### PR TITLE
Clamp negative random transactions

### DIFF
--- a/generator.sv
+++ b/generator.sv
@@ -90,6 +90,8 @@ class generator;
 
     // Decide how many random transactions to generate
     num_random_transactions = repeat_count - test_queue.size();
+    if (num_random_transactions < 0)
+      num_random_transactions = 0;
 
     // Add random transactions
     repeat (num_random_transactions) begin


### PR DESCRIPTION
## Summary
- ensure negative values for `num_random_transactions` are clamped to zero

## Testing
- `verilator --lint-only -Wall -cc $(cat build.list)` *(fails: Unsupported randomize constraints)*

------
https://chatgpt.com/codex/tasks/task_e_687d0016da108329a5fe205b0a71827f