### PR TITLE
Add 48-byte reset test

### DIFF
--- a/generator.sv
+++ b/generator.sv
@@ -3,6 +3,7 @@
 `include "test_5_head2.sv"
 `include "test_45_bytes.sv"
 `include "test_47_bytes.sv"
+`include "test_48_bytes.sv"
 `include "test_46_bytes.sv"
 `include "test_illegal_headers_with_a_valid_header_in_the_middle_frame.sv"
 `include "test_3_random_valid_headers.sv"
@@ -46,6 +47,7 @@ class generator;
     TEST_5_HEAD2,
     TEST_ILLEGAL_HEADERS_WITH_A_VALID_HEADER_IN_THE_MIDDLE_FRAME,
     TEST_47_BYTES,
+    TEST_48_BYTES,
     TEST_46_BYTES,
     TEST_ILLEGAL_HEADERS_WITH_A_VALID_HEADER_IN_THE_MIDDLE_FRAME_10_CLOCK,
     TEST_3_RANDOM_VALID_HEADERS,
@@ -75,15 +77,15 @@ class generator;
     total_transactions_sent = 0; 
 
 
-    // Add each test ID 3 times (for tests 0 to 14)
-    for (int i = 0; i <= 14; i++) begin // total 15 tests
+    // Add each test ID 3 times (for tests 0 to 15)
+    for (int i = 0; i <= 15; i++) begin // total 16 tests
       test_id_t test_id = test_id_t'(i); // cast integer to enum
       repeat (3) begin
         test_queue.push_back(test_id);
       end
     end
 
-    // Add the specific test 30 times (test ID 15)
+    // Add the specific test 30 times (test ID 16)
     repeat (30) begin
       test_queue.push_back(TEST_ILLEGAL_HEADERS_WITH_A_VALID_HEADER_IN_THE_MIDDLE_FRAME_RANDOM);
     end
@@ -121,6 +123,9 @@ class generator;
         end
         TEST_47_BYTES: begin
           test_47_bytes(gen2drv, total_transactions_sent);
+        end
+        TEST_48_BYTES: begin
+          test_48_bytes(gen2drv, total_transactions_sent);
         end
         TEST_46_BYTES: begin
           test_46_bytes(gen2drv, total_transactions_sent);

--- a/test_48_bytes.sv
+++ b/test_48_bytes.sv
@@ -1,0 +1,38 @@
+// Test has a 50-byte frame with header starting at byte 48
+
+// The expectation is that frame_detect clears after 48 illegal bytes
+// before recognizing the new header.
+task test_48_bytes(mailbox gen2drv, ref int total_transactions_sent);
+  transaction trans;
+
+  // Frame of 50 bytes with a valid LSB at byte 48 and valid MSB at byte 49
+  trans = new();
+  // Force the header type to ILLEGAL
+  if (!trans.randomize() with {header_type == transaction::ILLEGAL;}) begin
+    $fatal("Randomization failed for ILLEGAL transaction");
+  end
+
+  // Manually set the frame of size 48 bytes of illegal data
+  trans.payload = new[48];
+  trans.frame = new[50];
+  // Fill the frame with arbitrary illegal data
+  for (int i = 0; i < trans.frame.size(); i++) begin
+    trans.frame[i] = 8'h00; // illegal bytes
+  end
+  // Insert a valid header after 48 illegal bytes
+  trans.frame[48] = 8'hAA; // valid LSB
+  trans.frame[49] = 8'hAF; // valid MSB
+
+  // Display the generated transaction
+  $display("[ --Generator-- ] Generated Transaction 1:");
+  $display("  Header Type    : ILLEGAL");
+  $display("  Frame Size     : %0d bytes", trans.frame.size());
+  $display("  Frame Data     : {");
+  foreach (trans.frame[i]) $display("    Byte %0d: 0x%0h", i, trans.frame[i]);
+  $display("  }");
+
+  // Send the transaction to driver
+  gen2drv.put(trans);
+  total_transactions_sent++;
+
+endtask


### PR DESCRIPTION
## Summary
- add new directed test `test_48_bytes.sv`
- include the test in `generator.sv`
- extend test enumeration and update loops

## Testing
- `iverilog -g2012 -s testbench_top -c build.list -o simv && vvp simv` *(fails: command not found or unsupported SystemVerilog syntax)*

------
https://chatgpt.com/codex/tasks/task_e_687d302a975883299ff0cd445d92fec6